### PR TITLE
1.0.5

### DIFF
--- a/.docs/README_template.rst
+++ b/.docs/README_template.rst
@@ -1,4 +1,4 @@
-Version 1.0.5 as of 2020-07-29, see changelog_
+Version 1.0.6a0 as of 2020-07-29, see changelog_
 
 =======================================================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 - new PATCH version for backwards compatible bug fixes
 
 
+1.0.6a0
+--------
+2020-07-29: development
+
+
 1.0.5
 --------
 2020-07-29: feature release

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Version 1.0.5 as of 2020-07-29, see changelog_
+Version 1.0.6a0 as of 2020-07-29, see changelog_
 
 =======================================================
 
@@ -795,6 +795,11 @@ Changelog
 - new MAJOR version for incompatible API changes,
 - new MINOR version for added functionality in a backwards compatible manner
 - new PATCH version for backwards compatible bug fixes
+
+
+1.0.6a0
+--------
+2020-07-29: development
 
 
 1.0.5

--- a/lib_travis/__init__conf__.py
+++ b/lib_travis/__init__conf__.py
@@ -1,6 +1,6 @@
 name = 'lib_travis'
 title = 'travis related utilities'
-version = '1.0.5'
+version = '1.0.6a0'
 url = 'https://github.com/bitranox/lib_travis'
 author = 'Robert Nowotny'
 author_email = 'bitranox@gmail.com'
@@ -14,7 +14,7 @@ Info for lib_travis:
 
     travis related utilities
 
-    Version : 1.0.5
+    Version : 1.0.6a0
     Url     : https://github.com/bitranox/lib_travis
     Author  : Robert Nowotny
     Email   : bitranox@gmail.com""")

--- a/lib_travis/lib_travis.py
+++ b/lib_travis/lib_travis.py
@@ -682,7 +682,7 @@ def do_deploy() -> bool:
         - when $deploy_on_pypi = True
         - when TRAVIS_TAG != ''
     """
-    if get_env_or_blank('TRAVIS_TAG') != '':
+    if not get_env_or_blank('TRAVIS_TAG'):
         return False
     if not get_env_or_blank('PYPI_PASSWORD'):
         return False

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ if is_travis_deploy() and is_tagged_commit():
 
 setup_kwargs: Dict[str, Any] = dict()
 setup_kwargs['name'] = 'lib_travis'
-setup_kwargs['version'] = '1.0.5'
+setup_kwargs['version'] = '1.0.6a0'
 setup_kwargs['url'] = 'https://github.com/bitranox/lib_travis'
 setup_kwargs['packages'] = find_packages()
 setup_kwargs['package_data'] = {'lib_travis': ['py.typed', '*.pyi', '__init__.pyi']}


### PR DESCRIPTION
1.0.5
--------
2020-07-29: feature release
    - pass correct package name to mypy and codecov


1.0.4
--------
2020-07-29: feature release
    - use the new pizzacutter template
    - use cli_exit_tools