### PR TITLE
1.0.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -767,9 +767,12 @@ following modules will be automatically installed :
 
     ## Project Requirements
     click
-    cli_exit_tools @ git+https://github.com/bitranox/cli_exit_tools.git
-    lib_log_utils @ git+https://github.com/bitranox/lib_log_utils.git
-    rst_include @ git+https://github.com/bitranox/rst_include.git
+    # cli_exit_tools @ git+https://github.com/bitranox/cli_exit_tools.git
+    # lib_log_utils @ git+https://github.com/bitranox/lib_log_utils.git
+    # rst_include @ git+https://github.com/bitranox/rst_include.git
+    cli_exit_tools
+    lib_log_utils
+    rst_include
 
 Acknowledgements
 ----------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 ## Project Requirements
 click
-cli_exit_tools @ git+https://github.com/bitranox/cli_exit_tools.git
-lib_log_utils @ git+https://github.com/bitranox/lib_log_utils.git
-rst_include @ git+https://github.com/bitranox/rst_include.git
+# cli_exit_tools @ git+https://github.com/bitranox/cli_exit_tools.git
+# lib_log_utils @ git+https://github.com/bitranox/lib_log_utils.git
+# rst_include @ git+https://github.com/bitranox/rst_include.git
+cli_exit_tools
+lib_log_utils
+rst_include


### PR DESCRIPTION
1.0.5
--------
2020-07-29: feature release
    - pass correct package name to mypy and codecov


1.0.4
--------
2020-07-29: feature release
    - use the new pizzacutter template
    - use cli_exit_tools