### PR TITLE
v2.3.8

### DIFF
--- a/.docs/README_template.rst
+++ b/.docs/README_template.rst
@@ -2,7 +2,7 @@ lib_travis
 ==========
 
 
-Version v2.3.7 as of 2020-10-09 see `Changelog`_
+Version v2.3.8 as of 2021-02-15 see `Changelog`_
 
 
 .. include:: ./badges.rst

--- a/.docs/badges.rst
+++ b/.docs/badges.rst
@@ -4,7 +4,7 @@
 
 
 .. |travis_build| image:: https://img.shields.io/travis/bitranox/lib_travis/master.svg
-   :target: https://travis-ci.org/bitranox/lib_travis
+   :target: https://travis-ci.com/bitranox/lib_travis
 
 .. |license| image:: https://img.shields.io/github/license/webcomics/pywine.svg
    :target: http://en.wikipedia.org/wiki/MIT_License

--- a/.docs/tested_under.rst
+++ b/.docs/tested_under.rst
@@ -1,3 +1,3 @@
-tested on linux "bionic" with python 3.6, 3.7, 3.8, 3.9-dev, pypy3 - architectures: amd64, ppc64le, s390x, arm64
+tested on linux "bionic" with python 3.6, 3.7, 3.8, 3.9, 3.9-dev, pypy3 - architectures: amd64, ppc64le, s390x, arm64
 
 `100% code coverage <https://codecov.io/gh/bitranox/lib_travis>`_, flake8 style checking ,mypy static type checking ,tested under `Linux, macOS <https://travis-ci.org/bitranox/lib_travis>`_, automatic daily builds and monitoring

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,18 @@ matrix:
       language: python
       python: "3.8"
       before_install:
+          - export BUILD_DOCS="False"
+          - export DEPLOY_SDIST="True"
+          - export DEPLOY_WHEEL="True"
+          - export BUILD_TEST="True"
+          - export MYPY_DO_TESTS="True"
+
+    - os: linux
+      arch: "amd64"
+      if: true
+      language: python
+      python: "3.9"
+      before_install:
           - export BUILD_DOCS="True"
           - export DEPLOY_SDIST="True"
           - export DEPLOY_WHEEL="True"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 - new MINOR version for added functionality in a backwards compatible manner
 - new PATCH version for backwards compatible bug fixes
 
+v2.3.8
+--------
+2021-02-15: service release
+    - install rust compiler for pypy3 on linux, needed for twine
+
 v2.3.7
 --------
 2020-10-09: service release

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 1990-2020 Robert Nowotny
+Copyright (c) 1990-2021 Robert Nowotny
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ lib_travis
 ==========
 
 
-Version v2.3.7 as of 2020-10-09 see `Changelog`_
+Version v2.3.8 as of 2021-02-15 see `Changelog`_
 
 |travis_build| |license| |jupyter| |pypi| |black|
 
@@ -10,7 +10,7 @@ Version v2.3.7 as of 2020-10-09 see `Changelog`_
 
 
 .. |travis_build| image:: https://img.shields.io/travis/bitranox/lib_travis/master.svg
-   :target: https://travis-ci.org/bitranox/lib_travis
+   :target: https://travis-ci.com/bitranox/lib_travis
 
 .. |license| image:: https://img.shields.io/github/license/webcomics/pywine.svg
    :target: http://en.wikipedia.org/wiki/MIT_License
@@ -58,7 +58,7 @@ automated tests, Travis Matrix, Documentation, Badges, etc. are managed with `Pi
 
 Python version required: 3.6.0 or newer
 
-tested on linux "bionic" with python 3.6, 3.7, 3.8, 3.9-dev, pypy3 - architectures: amd64, ppc64le, s390x, arm64
+tested on linux "bionic" with python 3.6, 3.7, 3.8, 3.9, 3.9-dev, pypy3 - architectures: amd64, ppc64le, s390x, arm64
 
 `100% code coverage <https://codecov.io/gh/bitranox/lib_travis>`_, flake8 style checking ,mypy static type checking ,tested under `Linux, macOS <https://travis-ci.org/bitranox/lib_travis>`_, automatic daily builds and monitoring
 
@@ -493,6 +493,18 @@ python methods:
           language: python
           python: "3.8"
           before_install:
+              - export BUILD_DOCS="False"
+              - export DEPLOY_SDIST="True"
+              - export DEPLOY_WHEEL="True"
+              - export BUILD_TEST="True"
+              - export MYPY_DO_TESTS="True"
+
+        - os: linux
+          arch: "amd64"
+          if: true
+          language: python
+          python: "3.9"
+          before_install:
               - export BUILD_DOCS="True"
               - export DEPLOY_SDIST="True"
               - export DEPLOY_WHEEL="True"
@@ -730,6 +742,11 @@ Changelog
 - new MAJOR version for incompatible API changes,
 - new MINOR version for added functionality in a backwards compatible manner
 - new PATCH version for backwards compatible bug fixes
+
+v2.3.8
+--------
+2021-02-15: service release
+    - install rust compiler for pypy3 on linux, needed for twine
 
 v2.3.7
 --------

--- a/lib_travis/__init__conf__.py
+++ b/lib_travis/__init__conf__.py
@@ -1,6 +1,6 @@
 name = "lib_travis"
 title = "travis related utilities"
-version = "v2.3.7"
+version = "v2.3.8"
 url = "https://github.com/bitranox/lib_travis"
 author = "Robert Nowotny"
 author_email = "bitranox@gmail.com"
@@ -15,7 +15,7 @@ Info for lib_travis:
 
     travis related utilities
 
-    Version : v2.3.7
+    Version : v2.3.8
     Url     : https://github.com/bitranox/lib_travis
     Author  : Robert Nowotny
     Email   : bitranox@gmail.com"""

--- a/lib_travis/lib_travis.py
+++ b/lib_travis/lib_travis.py
@@ -213,12 +213,14 @@ def install(dry_run: bool = True) -> None:
         command=" ".join([pip_prefix, "install --upgrade readme_renderer"]),
     )
 
-    if os.getenv('python').lower().startswith('pypy3') and os.getenv('TRAVIS_OS_NAME').lower().startswith('linux'):
+    if os.getenv("python").lower().startswith("pypy3") and os.getenv(
+        "TRAVIS_OS_NAME"
+    ).lower().startswith("linux"):
         # for pypy3 install rust compiler on linux
         run(
             description="install rust compiler",
             command="curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
-            )
+        )
     run(
         description="install twine",
         command=" ".join([pip_prefix, "install --upgrade twine"]),

--- a/lib_travis/lib_travis.py
+++ b/lib_travis/lib_travis.py
@@ -212,6 +212,13 @@ def install(dry_run: bool = True) -> None:
         description="install readme renderer",
         command=" ".join([pip_prefix, "install --upgrade readme_renderer"]),
     )
+
+    if os.getenv('python').lower().startswith('pypy3') and os.getenv('TRAVIS_OS_NAME').lower().startswith('linux'):
+        # for pypy3 install rust compiler on linux
+        run(
+            description="install rust compiler",
+            command="curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
+            )
     run(
         description="install twine",
         command=" ".join([pip_prefix, "install --upgrade twine"]),

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if is_travis_deploy() and is_tagged_commit():
 
 setup_kwargs: Dict[str, Any] = dict()
 setup_kwargs["name"] = "lib_travis"
-setup_kwargs["version"] = "v2.3.7"
+setup_kwargs["version"] = "v2.3.8"
 setup_kwargs["url"] = "https://github.com/bitranox/lib_travis"
 setup_kwargs["packages"] = find_packages()
 setup_kwargs["package_data"] = {"lib_travis": ["py.typed", "*.pyi", "__init__.pyi"]}


### PR DESCRIPTION
v2.3.8
2021-02-15: service release
install rust compiler for pypy3 on linux, needed for twine